### PR TITLE
feat: add vehicle attachment compatibility

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,6 +1,6 @@
 import alt from "alt-client";
 
-import { KeyCode, metaKey, VehicleIndicatorLights } from '../shared/types';
+import { KeyCode, metaKey, VehicleIndicatorLights } from "../shared/types.js";
 
 // @ts-ignore
 alt.on("keydown", (key: KeyCode) => {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -6,10 +6,7 @@ alt.onClient("indicators:update", (player: alt.Player, vehicle: alt.Vehicle, ind
 	if (vehicle.driver?.id !== player.id) return;
 
 	vehicle.setStreamSyncedMeta(metaKey, indicatorLights);
-
-	if (vehicle.attached) {
-		vehicle.attached.setStreamSyncedMeta(metaKey, indicatorLights);
-	}
+	vehicle.attached?.setStreamSyncedMeta(metaKey, indicatorLights);
 });
 
 alt.on('vehicleAttach', (attachedVehicle, vehicle) => {
@@ -23,4 +20,4 @@ alt.on('vehicleDetach', (detachedVehicle) => {
 	if (detachedVehicle.hasStreamSyncedMeta(metaKey)) {
 		detachedVehicle.deleteStreamSyncedMeta(metaKey);
 	}
-})
+});

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,6 +1,6 @@
 import alt from "alt-server";
 
-import { metaKey, VehicleIndicatorLights } from "../shared/types";
+import { metaKey, VehicleIndicatorLights } from "../shared/types.js";
 
 alt.onClient("indicators:update", (player: alt.Player, vehicle: alt.Vehicle, indicatorLights: VehicleIndicatorLights) => {
 	if (vehicle.driver?.id !== player.id) return;

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -6,4 +6,21 @@ alt.onClient("indicators:update", (player: alt.Player, vehicle: alt.Vehicle, ind
 	if (vehicle.driver?.id !== player.id) return;
 
 	vehicle.setStreamSyncedMeta(metaKey, indicatorLights);
+
+	if (vehicle.attached) {
+		vehicle.attached.setStreamSyncedMeta(metaKey, indicatorLights);
+	}
 });
+
+alt.on('vehicleAttach', (attachedVehicle, vehicle) => {
+	const indicatorLights = vehicle.getStreamSyncedMeta(metaKey)
+	if (indicatorLights) {
+		attachedVehicle.setStreamSyncedMeta(metaKey, indicatorLights);
+	}
+});
+
+alt.on('vehicleDetach', (detachedVehicle) => {
+	if (detachedVehicle.hasStreamSyncedMeta(metaKey)) {
+		detachedVehicle.deleteStreamSyncedMeta(metaKey);
+	}
+})


### PR DESCRIPTION
Only the server has access to vehicle attachment properties, and will check accordingly to reflect the indicator state.

2d6548648c425537626053632febec00eb55e759 notes the incorrect argument signature for the event.